### PR TITLE
Perbaikan data type untuk RSSI

### DIFF
--- a/ESP8266-ZeroTwin English/ESP8266-ZeroTwin English.ino
+++ b/ESP8266-ZeroTwin English/ESP8266-ZeroTwin English.ino
@@ -168,7 +168,7 @@ typedef struct
   String ssid;
   uint8_t ch;
   uint8_t bssid[6];
-  uint8_t rssi;
+  int8_t rssi;
 }  _Network;
 
 

--- a/ESP8266-ZeroTwin Indonesian/ESP8266-ZeroTwin Indonesian.ino
+++ b/ESP8266-ZeroTwin Indonesian/ESP8266-ZeroTwin Indonesian.ino
@@ -168,7 +168,7 @@ typedef struct
   String ssid;
   uint8_t ch;
   uint8_t bssid[6];
-  uint8_t rssi;
+  int8_t rssi;
 }  _Network;
 
 


### PR DESCRIPTION
RSSI satuannya dBm yang dimana nilai nya 0 - negative, sedangkan datatype pada script arduino ini RSSI di berikan dataType uint8_t yang dimana unsigned integer ini tidak dapat merepresentasikan nilai negative, pull request ini hanya merubah data Type RSSI dari uint8_t menjadi int8_t